### PR TITLE
Add default chaser app

### DIFF
--- a/c_arduino_platformio/README.md
+++ b/c_arduino_platformio/README.md
@@ -4,13 +4,13 @@ The objective of this version is to use TDD for embedded software.
 
 Two environment will be available for tests : `native` and `cross`.
 
-The `native` enviroment is the host machine. This is the environment we are used to use. The test phases are here:
+The `native` enviroment is a standard C toolchain on the kata host. This is the kind of environment we are used to use. The test phases are here:
 
 - Compile the test code
 - Execute the test code
 - Inspect output on the standard output
 
-The provided `cross` environment uses a cross compiler for Microchip AVR chip, which drive Arduino boards.
+The provided `cross` environment uses a cross compiler for Microchip AVR chip, which drive Arduino boards. The cross compiler is also available on kata host.
 When using the `cross` environment, the test phases are:
 
 - Compile the test software using cross toolchain
@@ -21,20 +21,7 @@ When using the `cross` environment, the test phases are:
 Notes:
 
 - Some difficulties are tied to `native`/`cross` environments development (e.g. hardware interaction won't compile on `native`)
-- The exact model may have to be changed in `platformio.ini`. Default is an Arduino Mega.
+- The exact model may have to be changed in `platformio.ini`. Default is an Arduino Pro Micro.
 - The COM port associated with the board may have to be changed. Default is COM14
 - Better experience would be the usage of PlatformIO extension in Visual Studio Code.
-
-To run the tests on both environment:
-
-    pio test
-
-To run the tests on the host:
-
-    pio test -e native
-
-To run the tests on the target board:
-
-    pio test -e cross
-
-## Known Issues
+- Default firmware, with no link with the kata but activating leds is provided. To install it on the remote kata host: `pio remote run -t upload -r`

--- a/c_arduino_platformio/platformio.ini
+++ b/c_arduino_platformio/platformio.ini
@@ -5,15 +5,17 @@ default_envs = native, cross
 
 [env:cross]
 framework = arduino
-upload_port = COM14
 platform = atmelavr
-board = megaatmega2560
+board = sparkfun_promicro16
 # build_flags = -v
 
 test_framework = unity
-# upload_flags = -v
 monitor_speed = 115200
-test_port = COM14
+test_port = /dev/ttyACM0
+
+upload_port = /dev/ttyACM0
+upload_speed = 115200
+# upload_flags = -v
 
 [env:native]
 platform=native

--- a/c_arduino_platformio/src/chaser.cpp
+++ b/c_arduino_platformio/src/chaser.cpp
@@ -1,0 +1,41 @@
+#if defined(AVR)
+
+#include <Arduino.h>
+
+void setup() {
+  pinMode(6, OUTPUT);
+  pinMode(7, OUTPUT);
+  pinMode(8, OUTPUT);
+  pinMode(9, OUTPUT);
+
+  digitalWrite(9, HIGH);
+  digitalWrite(8, HIGH);
+  digitalWrite(7, HIGH);
+  digitalWrite(6, HIGH);
+
+  pinMode(LED_BUILTIN_RX, INPUT);
+  pinMode(LED_BUILTIN_TX, INPUT);
+}
+
+void loop() {
+  digitalWrite(6, LOW);
+  delay(1000);
+  digitalWrite(7, LOW);
+  delay(1000);
+  digitalWrite(8, LOW);
+  delay(1000);
+  digitalWrite(9, LOW);
+  delay(1000);
+
+  digitalWrite(6, HIGH);
+  delay(1000);
+  digitalWrite(7, HIGH);
+  delay(1000);
+  digitalWrite(8, HIGH);
+  delay(1000);
+  digitalWrite(9, HIGH);
+  delay(1000);
+}
+#else
+int main() {}
+#endif


### PR DESCRIPTION
Allow to set the target board with a default application when starting the Kata.